### PR TITLE
fix: replaced deprecated parameters

### DIFF
--- a/monitoring.tf
+++ b/monitoring.tf
@@ -26,11 +26,10 @@ resource "azurerm_monitor_diagnostic_setting" "monitoring_blob" {
   target_resource_id         = "${azurerm_storage_account.this.id}/blobServices/default"
   log_analytics_workspace_id = each.value
 
-  dynamic "log" {
+  dynamic "enabled_log" {
     for_each = var.log_category_list
     content {
-      category = log.value
-      enabled  = true
+      category = enabled_log.value
 
       retention_policy {
         days    = var.log_retention_days
@@ -60,11 +59,10 @@ resource "azurerm_monitor_diagnostic_setting" "monitoring_tables" {
   log_analytics_workspace_id     = each.value
   log_analytics_destination_type = var.destination_type
 
-  dynamic "log" {
+  dynamic "enabled_log" {
     for_each = var.log_category_list
     content {
-      category = log.value
-      enabled  = true
+      category = enabled_log.value
 
       retention_policy {
         days    = var.log_retention_days


### PR DESCRIPTION
```
╷
│ Warning: Argument is deprecated
│ 
│   with module.storage_clinical.azurerm_monitor_diagnostic_setting.monitoring_blob["log_analytics"],
│   on .terraform/modules/storage_clinical/monitoring.tf line 22, in resource "azurerm_monitor_diagnostic_setting" "monitoring_blob":
│   22: resource "azurerm_monitor_diagnostic_setting" "monitoring_blob" {
│ 
│ `log` has been superseded by `enabled_log` and will be removed in version
│ 4.0 of the AzureRM Provider.
│ 
│ (and 5 more similar warnings elsewhere)
╵
```